### PR TITLE
feat: add token index support for API key selection

### DIFF
--- a/internal/queue/dequeue.go
+++ b/internal/queue/dequeue.go
@@ -69,6 +69,17 @@ func (rb *RingBuffer) dequeueDispatchable(now time.Time) (*request.Request, int)
 
 	limits := rb.Limits
 
+	anyAvailable := false
+	for k := 0; k < len(*limits); k++ {
+		if (*limits)[k].CanAllow(now, rb.Priority) {
+			anyAvailable = true
+			break
+		}
+	}
+	if !anyAvailable {
+		return nil, -1
+	}
+
 	for i := int64(0); i < rb.count; i++ {
 		idx := (rb.head + i) % rb.size
 		req := rb.entries[idx]

--- a/internal/queue/dequeue.go
+++ b/internal/queue/dequeue.go
@@ -46,17 +46,9 @@ func (rb *RingBuffer) Process(max int) {
 
 	for i := 0; i < max && rb.count > 0; i++ {
 
-		keyId := rb.canDequeue(now)
-
-		if keyId < 0 {
-			break
-		}
-
-		req := rb.Dequeue(now)
+		req, keyId := rb.dequeueDispatchable(now)
 
 		if req == nil {
-			// This should not happen, but just in case
-			rb.Refund(keyId, now)
 			break
 		}
 
@@ -68,18 +60,70 @@ func (rb *RingBuffer) Process(max int) {
 	}
 }
 
-func (rb *RingBuffer) canDequeue(now time.Time) int {
+// dequeueDispatchable scans the queue for the first request that can be processed with an available API key
+// It removes the request from the array, shifts preceding elements, and returns the request and the assigned KeyId.
+func (rb *RingBuffer) dequeueDispatchable(now time.Time) (*request.Request, int) {
+	if rb.count == 0 {
+		return nil, -1
+	}
+
 	limits := rb.Limits
 
-	// Cycle through the key and check for one that allows the request
-	for i := 0; i < len(*limits); i++ {
-		if (*limits)[i].TryAllow(now, rb.Priority) {
-			return i
+	for i := int64(0); i < rb.count; i++ {
+		idx := (rb.head + i) % rb.size
+		req := rb.entries[idx]
+
+		if req == nil {
+			continue
+		}
+
+		// Skip expired requests
+		if now.UnixMilli() >= req.Expire {
+			continue
+		}
+
+		availableKeyId := -1
+
+		if req.TokenIndex != nil {
+			// Specific token requested
+			if *req.TokenIndex < len(*limits) && (*limits)[*req.TokenIndex].TryAllow(now, rb.Priority) {
+				availableKeyId = *req.TokenIndex
+			}
+		} else {
+			// Any token
+			for k := 0; k < len(*limits); k++ {
+				if (*limits)[k].TryAllow(now, rb.Priority) {
+					availableKeyId = k
+					break
+				}
+			}
+		}
+
+		if availableKeyId >= 0 {
+			// We can dispatch this request.
+			// Shift all elements before this one forward by 1 to fill the hole.
+			if i > 0 {
+				for j := i; j > 0; j-- {
+					currIdx := (rb.head + j) % rb.size
+					prevIdx := (rb.head + j - 1 + rb.size) % rb.size
+					rb.entries[currIdx] = rb.entries[prevIdx]
+				}
+			}
+
+			// Empty spot is now at the head, dequeue it normally
+			rb.entries[rb.head] = nil
+			rb.head = (rb.head + 1) % rb.size
+			rb.count--
+
+			if rb.count == 0 {
+				rb.lastUpdated = time.Now()
+			}
+
+			return req, availableKeyId
 		}
 	}
 
-	return -1
-
+	return nil, -1
 }
 
 func (rb *RingBuffer) needsUpdate(keyId int, now time.Time) bool {

--- a/internal/ratelimiter/requestHandler.go
+++ b/internal/ratelimiter/requestHandler.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/DarkIntaqt/cosmic-radiance/internal/metrics"
@@ -55,8 +56,21 @@ func (rl *RateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	timeout := rl.opts.Timeout
+
+	var tokenIndex *int
+	tokenIndexHeader := r.Header.Get("X-Riot-Token-Index")
+	if tokenIndexHeader != "" {
+		if idx, err := strconv.Atoi(tokenIndexHeader); err == nil && idx >= 0 {
+			tokenIndex = &idx
+		} else {
+			w.Header().Set("Retry-After", "0")
+			http.Error(w, "Invalid X-Riot-Token-Index", http.StatusBadRequest)
+			return
+		}
+	}
+
 	// Create a new request
-	req := request.NewRequest(timeout)
+	req := request.NewRequest(timeout, tokenIndex)
 
 	// Don't leave dangling channels open
 	// defer close(req.Response)

--- a/internal/ratelimiter/requestHandler.go
+++ b/internal/ratelimiter/requestHandler.go
@@ -60,7 +60,7 @@ func (rl *RateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var tokenIndex *int
 	tokenIndexHeader := r.Header.Get("X-Riot-Token-Index")
 	if tokenIndexHeader != "" {
-		if idx, err := strconv.Atoi(tokenIndexHeader); err == nil && idx >= 0 {
+		if idx, err := strconv.Atoi(tokenIndexHeader); err == nil && idx >= 0 && idx < len(rl.opts.ApiKeys) {
 			tokenIndex = &idx
 		} else {
 			w.Header().Set("Retry-After", "0")

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -12,6 +12,7 @@ const (
 
 type Request struct {
 	Expire      int64 // Expiration timestamp in milliseconds
+	TokenIndex  *int
 	Response    chan *ResponseChannel
 	Invalidated bool
 }
@@ -25,9 +26,10 @@ type ResponseChannel struct {
 /*
 Creates a new request with expiration time
 */
-func NewRequest(expire time.Duration) *Request {
+func NewRequest(expire time.Duration, tokenIndex *int) *Request {
 	return &Request{
 		Expire:      time.Now().Add(expire).UnixMilli(),
+		TokenIndex:  tokenIndex,
 		Response:    make(chan *ResponseChannel, 1), // A buffer of 1 to avoid blocking
 		Invalidated: false,
 	}

--- a/internal/resource/ratelimitgroup.go
+++ b/internal/resource/ratelimitgroup.go
@@ -34,6 +34,58 @@ func (rlg *RateLimitGroup) NeedsUpdate(now time.Time) bool {
 }
 
 /*
+Checks if a request can be allowed through the rate limit without consuming quota.
+*/
+func (rlg *RateLimitGroup) CanAllow(now time.Time, priority request.Priority) bool {
+	if rlg.PlatformLimits.LockedUntil.After(now) || rlg.MethodLimits.LockedUntil.After(now) {
+		return false
+	}
+
+	// Loop through all available limits
+	for i := range rlg.PlatformLimits.RateLimits {
+		rl := rlg.PlatformLimits.RateLimits[i]
+
+		if rl.Current >= rl.Limit {
+			return false
+		}
+
+		if priority == request.HighPriority {
+			continue
+		}
+
+		// Compute how many requests should have been allowed by now ideally
+		elapsed := now.Sub(rl.LastRefill)
+		idealAllowed := int(math.Min(float64(elapsed)/float64(rl.Window)*float64(rl.Limit)+1, float64(rl.Limit)))
+
+		if rl.Current > idealAllowed {
+			return false
+		}
+	}
+
+	for i := range rlg.MethodLimits.RateLimits {
+		rl := rlg.MethodLimits.RateLimits[i]
+
+		if rl.Current >= rl.Limit {
+			return false
+		}
+
+		if priority == request.HighPriority {
+			continue
+		}
+
+		// Compute how many requests should have been allowed by now ideally
+		elapsed := now.Sub(rl.LastRefill)
+		idealAllowed := int(math.Min(float64(elapsed)/float64(rl.Window)*float64(rl.Limit)+1, float64(rl.Limit)))
+
+		if rl.Current > idealAllowed {
+			return false
+		}
+	}
+
+	return true
+}
+
+/*
 Tries to allow a request through the rate limit.
 If the request is allowed, it consumes the available quota.
 */


### PR DESCRIPTION
Previously, all requests were treated the same. She system would find any available API key, then always dequeue the head of the queue. Requests had no way to specify which API key to use.

This PR adds token pinning: callers can set X-Riot-Token-Index: N to request a specific API key by index (starting with 0). This required reworking how requests are dispatched, because strict FIFO breaks when the head of the queue needs a specific key that's rate-limited while later requests could use other available keys.

The core change replaces the old two-step canDequeue() -> Dequeue() flow [dequeue.go:49-55](https://github.com/DarkIntaqt/cosmic-radiance/pull/10/changes#diff-927f187dd8bd483d75592752acccf29d21770507dad24080fbd7a82b95625299L49-L55) with a single dequeueDispatchable [dequeue.go:63-65](https://github.com/DarkIntaqt/cosmic-radiance/pull/10/changes#diff-927f187dd8bd483d75592752acccf29d21770507dad24080fbd7a82b95625299R63) that scans the queue for the first request that can be served right now.

